### PR TITLE
Allow multiple arrivals to same destination

### DIFF
--- a/MapboxCoreNavigation/RouteController.swift
+++ b/MapboxCoreNavigation/RouteController.swift
@@ -231,7 +231,7 @@ open class RouteController: NSObject {
         if legProgress.remainingSteps.count <= 2 && remainingVoiceInstructions.count <= 2 {
             
             let willArrive = status.routeState == .tracking
-            let didArrive = status.routeState == .complete && currentDestination != previousArrivalWaypoint
+            let didArrive = status.routeState == .complete
             
             if willArrive {
                 


### PR DESCRIPTION
This PR remove the condition checking whether we previously arrived at the current destination to set arrival state. This allows us to "arrive" at the same destination multiple times, in case the driver drove away. 